### PR TITLE
Add Admin Mode Authentication (Fixes #5)

### DIFF
--- a/src/static/index.html
+++ b/src/static/index.html
@@ -10,7 +10,34 @@
     <header>
       <h1>Mergington High School</h1>
       <h2>Extracurricular Activities</h2>
+      <div id="user-menu">
+        <button id="login-btn" class="user-icon">👤 Login</button>
+        <div id="user-info" class="hidden">
+          <span id="username-display"></span>
+          <button id="logout-btn">Logout</button>
+        </div>
+      </div>
     </header>
+
+    <!-- Login Modal -->
+    <div id="login-modal" class="modal hidden">
+      <div class="modal-content">
+        <span class="close">&times;</span>
+        <h3>Teacher Login</h3>
+        <form id="login-form">
+          <div class="form-group">
+            <label for="username">Username:</label>
+            <input type="text" id="username" required />
+          </div>
+          <div class="form-group">
+            <label for="password">Password:</label>
+            <input type="password" id="password" required />
+          </div>
+          <button type="submit">Login</button>
+          <div id="login-error" class="error hidden"></div>
+        </form>
+      </div>
+    </div>
 
     <main>
       <section id="activities-container">
@@ -23,6 +50,10 @@
 
       <section id="signup-container">
         <h3>Sign Up for an Activity</h3>
+        <div id="teacher-only-notice" class="notice hidden">
+          <p>⚠️ Only teachers can register and unregister students.</p>
+          <p>Please log in to manage student registrations.</p>
+        </div>
         <form id="signup-form">
           <div class="form-group">
             <label for="email">Student Email:</label>

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -198,3 +198,116 @@ footer {
   padding: 20px;
   color: #666;
 }
+
+/* User menu styles */
+#user-menu {
+  position: absolute;
+  top: 20px;
+  right: 20px;
+}
+
+.user-icon {
+  background-color: white;
+  color: #1a237e;
+  border: 2px solid white;
+  padding: 8px 16px;
+  font-size: 14px;
+  cursor: pointer;
+}
+
+.user-icon:hover {
+  background-color: #f0f0f0;
+}
+
+#user-info {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  color: white;
+}
+
+#username-display {
+  font-weight: bold;
+}
+
+#logout-btn {
+  background-color: #c62828;
+  padding: 6px 12px;
+  font-size: 14px;
+}
+
+#logout-btn:hover {
+  background-color: #d32f2f;
+}
+
+/* Modal styles */
+.modal {
+  position: fixed;
+  z-index: 1000;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.modal-content {
+  background-color: white;
+  padding: 30px;
+  border-radius: 8px;
+  width: 90%;
+  max-width: 400px;
+  position: relative;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+}
+
+.modal-content h3 {
+  margin-bottom: 20px;
+  color: #1a237e;
+  text-align: center;
+}
+
+.close {
+  position: absolute;
+  right: 15px;
+  top: 10px;
+  font-size: 28px;
+  font-weight: bold;
+  color: #aaa;
+  cursor: pointer;
+}
+
+.close:hover {
+  color: #000;
+}
+
+.notice {
+  background-color: #fff3cd;
+  border: 1px solid #ffc107;
+  color: #856404;
+  padding: 15px;
+  border-radius: 5px;
+  margin-bottom: 15px;
+}
+
+.notice p {
+  margin: 5px 0;
+}
+
+#login-error {
+  margin-top: 10px;
+}
+
+/* Hide delete buttons for non-authenticated users */
+body:not(.authenticated) .delete-btn {
+  display: none;
+}
+
+/* Disable form for non-authenticated users */
+body:not(.authenticated) #signup-form {
+  pointer-events: none;
+  opacity: 0.6;
+}

--- a/src/teachers.json
+++ b/src/teachers.json
@@ -1,0 +1,16 @@
+{
+  "teachers": [
+    {
+      "username": "teacher1",
+      "password": "password123"
+    },
+    {
+      "username": "teacher2",
+      "password": "password456"
+    },
+    {
+      "username": "admin",
+      "password": "admin123"
+    }
+  ]
+}


### PR DESCRIPTION
## Description
Implements teacher-only authentication to prevent students from removing each other from activities.

## Changes Made
- ✅ Added login/logout authentication system
- ✅ Protected signup and unregister endpoints (teachers only)
- ✅ Created `teachers.json` for credential storage
- ✅ Added login modal UI with user menu in header
- ✅ Session management with secure tokens stored in localStorage
- ✅ UI updates: hide delete buttons and disable forms when not authenticated
- ✅ Added teacher-only notice for non-authenticated users

## How to Test
1. Visit the application without logging in
   - You should see a notice that only teachers can register students
   - Delete buttons should be hidden
   - Signup form should be disabled/grayed out

2. Click the "👤 Login" button in the header
3. Use one of these test credentials:
   - `teacher1` / `password123`
   - `teacher2` / `password456`
   - `admin` / `admin123`

4. After logging in:
   - Notice disappears
   - Delete buttons (❌) appear next to participants
   - Signup form becomes enabled
   - Header shows "Teacher: username" with Logout button

5. Try registering/unregistering students - should work
6. Logout and verify forms are disabled again

## Security Notes
- All signup/unregister operations require authentication
- Session tokens are validated on each request
- Students can still view activities and participants (read-only)

Closes #5